### PR TITLE
rust test changes

### DIFF
--- a/postgres/src/test.rs
+++ b/postgres/src/test.rs
@@ -435,8 +435,9 @@ fn portal() {
     assert_eq!(rows.len(), 3);
     assert_eq!(rows[0].get::<_, i64>(0), 1);
     assert_eq!(rows[1].get::<_, i64>(0), 2);
-    assert_eq!(rows[1].get::<_, i64>(0), 2);
+    assert_eq!(rows[2].get::<_, i64>(0), 3);
 
+    // Vertica gets all rows, not just two for the query
     let rows = transaction.query_portal(&portal, 2).unwrap();
     assert_eq!(rows.len(), 3);
     assert_eq!(rows[0].get::<_, i64>(0), 1);


### PR DESCRIPTION
I added one test that does the basic SQL functions: Create a table, insert data, update it, and delete. 

The main obstacle so far has been prepared statements. It would take a lot of work to edit the driver and get them functional. Postgres uses $1, $2, etc for parameters while Vertica uses a ‘?’, which is why the query_prepared() test fails.

There were some small changes I had to make in a lot of the tests you can see in the diff. Some include: Vertica uses INT8 (64bit) instead of INT4 (32bit) for INT type, temporary tables can’t have SERIAL PRIMARY KEY, can’t insert DEFAULT values (which is NULL for INT).

Some tests were ignored because they have Postgres functionality that Vertica doesn’t have. These are:
Transaction_drop_immediate_rollback - no ON CONFLICT in Vertica
Binary_copy_in - no BINARY option for COPY
Copy_out and binary_copy_out -no COPY to STDOUT
Portal - I changed this test to get it to pass but it could be ignored. Portals work by processing data in chunks, while Vertica gets all the data at once. The test was changed to reflect that.
Notifications_iter, notifications_blocking_iter, and notifications_timeout_iter - no LISTEN

The COPY commands work with a little tweaking. Postgres uses the TEXT type and the UDx creates an alias for it with CREATE TYPE IF NOT EXISTS pg_catalog.text(x=varchar);
However, when trying to copy with TEXT type, I get an error that user created types are not allowed in COPY commands. Something to consider in the future.

Further, with COPY, there is no COPY FROM LOCAL so with a text file, you just have to feed it into STDIN.

The portal() test I had to change from a multi-row insert statement to separate insert statements. I noticed in the ADO.NET driver there’s nowhere that does multi-row inserts. Do we know why this doesn’t work?

TLS is not provided by the driver itself but external libraries postgres-openssl and postgres-native tls. The connection string can have the parameter “sslmode” with three options: disable, prefer, and require.

There’s likely other functionality that exists in Vertica and Postgres that we want to make sure works. If you have any idea what I should add tests for, let me know.

Edit: If you want to try out this branch for yourself, make sure you run the 'install.sql' script in server\udx\supported\pgcompat\ddl. 
Here are some useful links for understanding pgcompt and rust-postgres:
https://confluence.verticacorp.com/pages/viewpage.action?spaceKey=~akalinin&title=PG+ODBC+Investigation
https://confluence.verticacorp.com/pages/viewpage.action?spaceKey=~jslaunwhite&title=Potential+Paths+forward+for+Postgres+Compatibility
https://confluence.verticacorp.com/pages/viewpage.action?spaceKey=DEV&title=Comparison+of+Vertica+and+Postgres+Protocols
https://confluence.verticacorp.com/pages/viewpage.action?spaceKey=~akalinin&title=Postgres+Compatibility%3A+What+we+have+got+here+is+failure+to+communicate

